### PR TITLE
Fix packaging to include tutorial 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ cache:
 stages:
     - linting
     - test
-    - documentation
     - deploy
 
 install:
@@ -18,10 +17,12 @@ jobs:
     include:
         - python: 3.6
           env: TASK=py36
-
           after_success:
               - pip install coveralls
               - coveralls
+
+        - python: 3.6
+          env: TASK=docs
 
         - python: 3.7
           dist: xenial
@@ -30,10 +31,6 @@ jobs:
         - stage: linting
           python: 3.6
           env: TASK=lint
-
-        - stage: documentation
-          python: 3.6
-          env: TASK=docs
 
         - stage: deploy
           name: 'Package & Publish to PyPi'

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,7 @@ stages:
     - linting
     - test
     - documentation
-    - name: deploy
-      if: branch = master
+    - deploy
 
 install:
     - pip install tox
@@ -37,10 +36,9 @@ jobs:
           env: TASK=docs
 
         - stage: deploy
-          name: Publish to PyPi
+          name: 'Package & Publish to PyPi'
           python: 3.6
-          script:
-              - python setup.py sdist bdist_wheel
+          env: TASK=pkg
           deploy:
               provider: script
               skip_cleanup: true

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,6 @@
 include LICENSE
 include CHANGES.rst
 include README.md
+include pyproject.toml
 recursive-include stylo *.sh
 recursive-include stylo *.ipynb

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,5 @@
+include LICENSE
+include CHANGES.rst
 include README.md
-include requirements.txt
+recursive-include stylo *.sh
+recursive-include stylo *.ipynb

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,20 @@
+[build-system]
+requires = ["setuptools >= 35.0.2", "wheel >= 0.29.0"]
+build-backend = "setuptools.build_meta"
+
+[tool.check-manifest]
+ignore = [
+  "docs",
+  "docs/*",
+  ".coveragerc",
+  ".flake8",
+  "*.ipynb_checkpoints",
+  "*.ipynb_checkpoints/*",
+  "tests",
+  "tests/*"]
+
+[tool.tox]
+legacy_tox_ini = """
 [tox]
 envlist = lint, docs, py37
 
@@ -24,3 +41,13 @@ deps =
 commands =
     black --check stylo tests
     flake8 stylo/ tests/
+
+[testenv:pkg]
+deps =
+     check-manifest
+     wheel
+commands =
+
+     check-manifest
+     python setup.py sdist bdist_wheel
+"""

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,0 @@
-numpy
-Pillow

--- a/setup.py
+++ b/setup.py
@@ -31,6 +31,7 @@ setup(
     author_email="alcarneyme@gmail.com",
     license="MIT",
     packages=find_packages(".", exclude=["tests"]),
+    package_data={"stylo.cli.scripts": ["*.sh"], "stylo.tutorial": ["**/*.ipynb"]},
     python_requires=">=3.6",
     install_requires=required,
     extras_require=extras,

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,10 @@ setup(
     author_email="alcarneyme@gmail.com",
     license="MIT",
     packages=find_packages(".", exclude=["tests"]),
-    package_data={"stylo.cli.scripts": ["*.sh"], "stylo.tutorial": ["**/*.ipynb"]},
+    package_data={
+        "stylo.cli.scripts": ["*.sh"],
+        "stylo.tutorial": ["*.ipynb", "**/*.ipynb"],
+    },
     python_requires=">=3.6",
     install_requires=required,
     extras_require=extras,


### PR DESCRIPTION
- Wheels and sdists should now include the tutorial
- Use `check-manifest` to ensure our packing stays fixed
- Start using a `pyproject.toml` file