### PR TITLE
Pre commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,3 +13,11 @@ repos:
   rev: master
   hooks:
   - id: black
+
+- repo: local
+  hooks:
+  - id: clean-notebooks
+    name: clean-notebooks
+    entry: ./scripts/clean-notebooks.sh
+    language: script
+    files: \.ipynb$

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,9 @@
+repos:
+- repo: https://github.com/pre-commit/pre-commit-hooks
+  rev: master
+  hooks:
+  - id: flake8
+- repo: https://github.com/python/black
+  rev: master
+  hooks:
+  - id: black

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,6 +3,12 @@ repos:
   rev: master
   hooks:
   - id: flake8
+
+- repo: https://github.com/pre-commit/mirrors-isort
+  rev: master
+  hooks:
+  - id: isort
+
 - repo: https://github.com/python/black
   rev: master
   hooks:

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ install:
     - pip install tox
 
 script:
-    - tox -r -e $TASK
+    - tox -q -e $TASK
 
 jobs:
     include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ install:
     - pip install tox
 
 script:
-    - tox -q -e $TASK
+    - tox -r -e $TASK
 
 jobs:
     include:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,9 @@ commands =
     sphinx-build -M html docs docs/_build -E -a -j auto
 
 [testenv:lint]
-deps = pre-commit
+deps =
+     pre-commit
+     jupyter
 commands =
     pre-commit run --all-files
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,9 @@ build-backend = "setuptools.build_meta"
 ignore = [
   "docs",
   "docs/*",
+  ".pre-commit-config.yaml",
+  "scripts",
+  "scripts/*",
   ".coveragerc",
   ".flake8",
   "*.ipynb_checkpoints",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,12 +35,9 @@ commands =
     sphinx-build -M html docs docs/_build -E -a -j auto
 
 [testenv:lint]
-deps =
-    flake8
-    black
+deps = pre-commit
 commands =
-    black --check stylo tests
-    flake8 stylo/ tests/
+    pre-commit run --all-files
 
 [testenv:pkg]
 deps =

--- a/scripts/clean-notebooks.sh
+++ b/scripts/clean-notebooks.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+# This ensures that all of te tutorial notebook files have no
+# content when committed. It does the following:
+#
+# 1. Take the MD5 hash of the original file.
+# 2. Strip out all the output cells from the file, saving to a temp file
+# 3. Take the MD5 hash of the converted file.
+# 4. If they are different, copy the file over the original and add it to the
+#    list of modified
+
+for f in "$@"
+do
+    md5Orig=$(md5sum "$f" | cut -f 1 -d \  )
+
+    outDir=$(dirname "$f")
+    out="${outDir}/tmp.ipynb"
+
+    jupyter nbconvert --log-level=ERROR \
+            --ClearOutputPreprocessor.enabled=True \
+            --to notebook \
+            --output="tmp" \
+            "$f"
+
+    md5New=$(md5sum "$out" | cut -f 1 -d \  )
+
+    if [ "$md5New" == "$md5Orig" ]; then
+        echo "$f - Unchanged"
+        rm "$out"
+    else
+        echo "$f - Cleaned"
+        mv "$out" "$f"
+    fi
+
+done

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,6 @@
 import os
-from setuptools import setup, find_packages
+
+from setuptools import find_packages, setup
 
 info = {}
 version = os.path.join("stylo", "_version.py")

--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,11 @@
 import os
 from setuptools import setup, find_packages
 
+info = {}
 version = os.path.join("stylo", "_version.py")
 
 with open(version) as f:
-    exec(f.read())
+    exec(f.read(), info)
 
 
 def readme():
@@ -13,12 +14,12 @@ def readme():
 
 
 required = ["attr", "numpy", "Pillow", "Click", "matplotlib"]
-extras = {"dev": ["tox"], "examples": ["jupyterlab"]}
+extras = {"dev": ["tox", "pre-commit", "jupyterlab"], "examples": ["jupyterlab"]}
 
 
 setup(
     name="stylo",
-    version=__version__,
+    version=info["__version__"],
     project_urls={
         "Documentation": "https://stylo.readthedocs.io/en/latest",
         "Source": "https://github.com/swyddfa/stylo",

--- a/stylo/__init__.py
+++ b/stylo/__init__.py
@@ -1,8 +1,8 @@
+from ._version import __version__  # noqa: F401
 from .color import RGB8  # noqa: F401
 from .image import Image  # noqa: F401
-from .shapes import Canvas, shape  # noqa: F401
 from .loaders import load_parameters, load_shapes
-from ._version import __version__  # noqa: F401
+from .shapes import Canvas, shape  # noqa: F401
 
 Parameter = load_parameters()  # noqa: F401
 Shape = load_shapes()  # noqa: F401

--- a/stylo/__main__.py
+++ b/stylo/__main__.py
@@ -1,4 +1,5 @@
 import logging
+
 import pkg_resources
 
 import click

--- a/stylo/cli/runner.py
+++ b/stylo/cli/runner.py
@@ -1,11 +1,12 @@
 import collections
 import logging
 import os
-import pkg_resources
-import subprocess
 import stat
+import subprocess
 import sys
 import textwrap
+
+import pkg_resources
 
 logger = logging.getLogger(__name__)
 Result = collections.namedtuple("Result", "rcode, stdout, stderr")

--- a/stylo/cli/tutorial.py
+++ b/stylo/cli/tutorial.py
@@ -1,8 +1,9 @@
 import logging
 import os
-import pkg_resources
 import shutil
 import time
+
+import pkg_resources
 
 from .runner import Runner
 

--- a/stylo/context.py
+++ b/stylo/context.py
@@ -1,8 +1,7 @@
-import os
 import logging
+import os
 import sys
 import tempfile
-
 
 logger = logging.getLogger(__name__)
 

--- a/stylo/image.py
+++ b/stylo/image.py
@@ -1,6 +1,6 @@
 import base64
-import logging
 import io
+import logging
 
 import numpy as np
 import PIL.Image

--- a/stylo/loaders.py
+++ b/stylo/loaders.py
@@ -1,4 +1,5 @@
 import logging
+
 import pkg_resources
 
 logger = logging.getLogger(__name__)

--- a/stylo/shapes.py
+++ b/stylo/shapes.py
@@ -8,7 +8,6 @@ from .color import RGB8
 from .image import Image
 from .loaders import load_parameters
 
-
 Parameter = load_parameters()
 logger = logging.getLogger(__name__)
 

--- a/stylo/tutorial/The Basics/1 - Shapes and Images.ipynb
+++ b/stylo/tutorial/The Basics/1 - Shapes and Images.ipynb
@@ -19,6 +19,13 @@
     "image = circle(1920, 1080)\n",
     "image.show()"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {

--- a/tests/test_shapes.py
+++ b/tests/test_shapes.py
@@ -1,7 +1,7 @@
 import json
-import pytest
 
 import numpy as np
+import pytest
 import stylo as st
 
 


### PR DESCRIPTION
- Making use of `pre-commit` to manage and run a number of hooks on every commit. Currently we are using 3 hooks.
  + `black`: This ensures all our code is nicely formatted
  + `isort`: Ensures all our `import` statements are in a sane order
  + `clean-notebooks`: Custom script for our repository that ensures that each of the notebooks in our tutorial are always in a "clean" state i.e. no outputs are ever commited to the repository. (Closes #108) 
- Made it so that our `tox -e lint` step is equivalent to running all the hooks across the repository