### PR TITLE
Add custom `autoshape` directive

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ __pycache__/
 env/
 dist/
 docs/_build
+htmlcov
 
 *.png
 !docs/**/*.png
@@ -25,3 +26,4 @@ build
 pip-wheel-metadata
 .dev
 *.mo
+*.xml

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,19 @@
+v0.10.0 - Unreleased
+--------------------
+
+Stylo has been rewritten from the ground up (again...) which brings numerous
+improvements and enhancements to the previous version!
+
+Added
+^^^^^
+
+- Stylo now has an interactive tutorial! Once you install :code:`stylo` this
+  tutorial can be accessed by running the `$ stylo tutorial` command on the
+  command line.
+- There is now a much more succinct syntax for defining new shapes.
+
+
+
 v0.9.3 - 2019-01-12
 -------------------
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -10,10 +10,8 @@
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #
-# import os
-# import sys
-# sys.path.insert(0, os.path.abspath('.'))
 import stylo
+from stylo.doc import AutoShapeDirective
 
 # -- Project information -----------------------------------------------------
 
@@ -64,4 +62,16 @@ html_theme = "sphinx_rtd_theme"
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ["_static"]
+# html_static_path = ["_static"]
+
+# -- Extension Configuration -------------------------------------------------
+intersphinx_mapping = {
+    "python": ("https://docs.python.org/3", None),
+    "numpy": ("https://docs.scipy.org/doc/numpy/", None),
+}
+
+# -- Custom Configuration ----------------------------------------------------
+
+
+def setup(app):
+    app.add_directive("autoshape", AutoShapeDirective)

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -8,4 +8,5 @@ Stylo
    using/index
    extending/index
    contributing/index
+   stdlib/index
    changes

--- a/docs/stdlib/basic-shapes.rst
+++ b/docs/stdlib/basic-shapes.rst
@@ -1,0 +1,10 @@
+.. _stdlib_basic_shapes:
+
+Basic Shapes
+============
+
+.. autoshape:: stylo.lib.basic.Circle
+
+.. autoshape:: stylo.lib.basic.Ellipse
+
+.. autoshape:: stylo.lib.basic.Square

--- a/docs/stdlib/index.rst
+++ b/docs/stdlib/index.rst
@@ -1,0 +1,14 @@
+.. _stdlib:
+
+Standard Library
+================
+
+Having a system for defining shapes and creating images is only half of the
+battle. It's hard to see the utility if you have nothing to work with so
+:code:`stylo` also comes with a standard library of Shapes providing the basics
+everyone will need along with some useful utilities for various tasks.
+
+.. toctree::
+   :maxdepth: 1
+
+   basic-shapes

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ ignore = [
 [tool.tox]
 legacy_tox_ini = """
 [tox]
-envlist = pkg, lint, docs, py{36,37}, py{36,37}-doc
+envlist = pkg, lint, docs, py37
 isolated_build = True
 
 [testenv]
@@ -44,7 +44,6 @@ commands =
 deps =
      {[testenv:docs]deps}
      sphinx-autobuild
-usedevelop = True
 commands =
      sphinx-autobuild docs docs/_build/html -E -a {posargs}
 
@@ -60,7 +59,6 @@ deps =
      check-manifest
      wheel
 commands =
-
      check-manifest
      python setup.py sdist bdist_wheel
 """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,10 +20,12 @@ ignore = [
 [tool.tox]
 legacy_tox_ini = """
 [tox]
-envlist = lint, docs, py37
+envlist = pkg, lint, docs, py{36,37}, py{36,37}-doc
+isolated_build = True
 
 [testenv]
 deps =
+     .[all]
      pytest
      pytest-cov
      pytest-azurepipelines
@@ -34,10 +36,17 @@ commands =
 deps =
      sphinx
      sphinx_rtd_theme
+commands =
+    sphinx-build -M linkcheck docs docs/_build -E -a -j auto {posargs}
+    sphinx-build -M html docs docs/_build -E -a -j auto {posargs}
+
+[testenv:docs-preview]
+deps =
+     {[testenv:docs]deps}
+     sphinx-autobuild
 usedevelop = True
 commands =
-    sphinx-build -M linkcheck docs docs/_build -E -a -j auto
-    sphinx-build -M html docs docs/_build -E -a -j auto
+     sphinx-autobuild docs docs/_build/html -E -a {posargs}
 
 [testenv:lint]
 deps =

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,4 @@
+[pytest]
+markers =
+    core
+    doc

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,4 +1,0 @@
-[pytest]
-markers =
-    core
-    doc

--- a/setup.py
+++ b/setup.py
@@ -15,8 +15,15 @@ def readme():
 
 
 required = ["attrs", "numpy", "Pillow", "Click", "matplotlib"]
-extras = {"dev": ["tox", "pre-commit", "jupyterlab"], "examples": ["jupyterlab"]}
+extras = {
+    "dev": ["tox", "pre-commit", "jupyterlab"],
+    "doc": ["sphinx"],
+    "examples": ["jupyterlab"],
+}
 
+extras["all"] = list(
+    {item for name, items in extras.items() if name != "dev" for item in items}
+)
 
 setup(
     name="stylo",
@@ -61,9 +68,9 @@ setup(
             "t = stylo.parameters:ts",
         ],
         "stylo.shapes": [
-            "Circle = stylo.shapes:Circle",
-            "Ellipse = stylo.shapes:Ellipse",
-            "Square = stylo.shapes:Square",
+            "Circle = stylo.lib.basic:Circle",
+            "Ellipse = stylo.lib.basic:Ellipse",
+            "Square = stylo.lib.basic:Square",
         ],
     },
 )

--- a/stylo/__init__.py
+++ b/stylo/__init__.py
@@ -2,7 +2,7 @@ from ._version import __version__  # noqa: F401
 from .color import RGB8  # noqa: F401
 from .image import Image  # noqa: F401
 from .loaders import load_parameters, load_shapes
-from .shapes import Canvas, shape  # noqa: F401
+from .shapes import Canvas, Shape, shape  # noqa: F401
 
 Parameter = load_parameters()  # noqa: F401
 Shapes = load_shapes()  # noqa: F401

--- a/stylo/doc/__init__.py
+++ b/stylo/doc/__init__.py
@@ -1,0 +1,1 @@
+from .directives import AutoShapeDirective  # noqa: F401

--- a/stylo/doc/directives.py
+++ b/stylo/doc/directives.py
@@ -1,0 +1,186 @@
+"""A custom `autoshape` directive used to automatically document shape definitions
+in the spirit of the autodoc extension.
+"""
+import importlib
+import string
+import textwrap
+import traceback
+from typing import List
+
+import attr
+import stylo as st
+from docutils import nodes
+from docutils.parsers import rst
+from docutils.statemachine import StringList
+from sphinx.util import logging, nested_parse_with_titles
+
+logger = logging.getLogger(__name__)
+
+
+ERROR_TEMPLATE = """\
+.. error::
+
+${message}
+
+${traceback}
+"""
+
+SHAPE_TEMPLATE = """\
+${shape_name}
+
+.. py:class:: ${shape_path}
+
+${shape_image}
+
+${shape_desc}
+
+${shape_props}
+"""
+
+PROPS_TEMPLATE = """\
+:Properties:
+
+${props}
+"""
+
+PROP_TEMPLATE = """\
+- **${name}** ${type} - Default: :code:`${default}`
+"""
+
+PREVIEW_TEMPLATE = """\
+.. raw:: html
+
+   <figure>
+     <img alt="${alt_tag}"
+          src="data:image/png;base64,${img_data}"
+          style="border: solid 1px #ddd"/>
+     <figcaption style="margin: 10px;text-align:center">
+       <small style="font-style:italic">${alt_tag}</small>
+     </figcaption>
+   </figure>
+
+"""
+
+
+def load_shape(object_spec: str) -> st.Shape:
+    """Given a classpath e.g. :code:`stylo.shapes.Circle` load it."""
+
+    *obj_path, obj_name = object_spec.split(".")
+    obj_path = ".".join(obj_path)
+
+    logger.debug(f"[autoshape]: Looking for shape: {obj_name} in {obj_path}")
+
+    module = importlib.import_module(obj_path)
+    shape = getattr(module, obj_name)
+
+    if not issubclass(shape, st.Shape):
+        raise TypeError(f"{object_spec} is not a shape")
+
+    return shape
+
+
+def document_properties(shape: st.Shape) -> str:
+    """Given a shape's definitio, document all of its properties."""
+    template = string.Template(PROPS_TEMPLATE)
+    prop_tpl = string.Template(PROP_TEMPLATE)
+
+    properties = []
+
+    for prop in sorted(attr.fields(shape), key=lambda p: p.name):
+
+        ptype = "" if prop.type is None else f"({str(prop.type)})"
+        context = {"name": prop.name, "default": prop.default, "type": ptype}
+
+        properties.append(prop_tpl.safe_substitute(context))
+
+    return template.safe_substitute({"props": "\n".join(properties)})
+
+
+def generate_preview(shape_ins: st.Shape) -> str:
+    """Given an instance of the shape, generate a preview of it."""
+    template = string.Template(PREVIEW_TEMPLATE)
+    image = shape_ins(1920, 1080)
+    name = shape_ins.__class__.__name__
+
+    context = {
+        "img_data": image.encode().decode("utf-8"),
+        "alt_tag": f"Example instance of the {name} shape",
+    }
+
+    return template.safe_substitute(context)
+
+
+def document_shape(shape: st.Shape) -> StringList:
+    """Given a shape definition, automatically write the reference documentation
+    for it.
+    """
+    default = shape()
+    indent = " " * 3
+    template = string.Template(SHAPE_TEMPLATE)
+    docstring = "" if shape.__doc__ is None else shape.__doc__
+
+    context = {
+        "shape_name": shape.__name__ + "\n" + "-" * len(shape.__name__),
+        "shape_path": f"{shape.__module__}.{shape.__name__}",
+        "shape_desc": textwrap.indent(docstring, indent),
+        "shape_props": textwrap.indent(document_properties(shape), indent),
+        "shape_image": textwrap.indent(generate_preview(default), indent),
+    }
+
+    documentation = template.safe_substitute(context)
+
+    return StringList(documentation.split("\n"), source="")
+
+
+def format_error(message: str, err: str) -> StringList:
+    """Given an error message format it as an error."""
+
+    indent = " " * 3
+    msg = textwrap.indent(message + "::", indent)
+    err_msg = textwrap.indent(err, indent * 2)
+
+    template = string.Template(ERROR_TEMPLATE)
+    error = template.safe_substitute({"message": msg, "traceback": err_msg})
+
+    return StringList(error.split("\n"), source="")
+
+
+def parse_content(state, content: StringList) -> List[nodes.Node]:
+    """Given a reStructured text representation of some content format parse it
+    into a list of nodes."""
+
+    section = nodes.section()
+    section.document = state.document
+    nested_parse_with_titles(state, content, section)
+
+    return section.children
+
+
+class AutoShapeDirective(rst.Directive):
+    """Given the a shape definition automatically generate its documentation."""
+
+    required_arguments = 1
+    optional_arguments = 0
+    add_index = False
+
+    def run(self) -> List[nodes.Node]:
+
+        shape_name = self.arguments[0]
+
+        try:
+            shape = load_shape(shape_name)
+
+        except Exception:
+            err = traceback.format_exc()
+            message = f"**AutoShape:** Unable to load shape: :code:`{shape_name}`"
+            content = format_error(message, err)
+
+            return parse_content(self.state, content)
+
+        content = document_shape(shape)
+
+        section = nodes.section()
+        section.document = self.state.document
+        nested_parse_with_titles(self.state, content, section)
+
+        return section.children

--- a/stylo/lib/basic.py
+++ b/stylo/lib/basic.py
@@ -1,0 +1,62 @@
+import numpy as np
+from stylo import shape
+
+
+@shape
+def Circle(x, y, *, x0=0, y0=0, r=0.8, pt=None):
+    """We define a circle using the following inequality.
+
+    .. math::
+
+       \\sqrt{(x - x_0)^2 + (y - y_0)^2} < r^2
+
+    where:
+
+    - :math:`(x_0, y_0)`: Defines the centre
+    - :math:`r`: Controls the radius
+
+    In python these variables can be set using the :code:`x0`, :code:`y0`
+    and :code:`r` keyword arguments to the shape's constructor.
+
+    By default when drawn the shape will draw a filled in circle, however the
+    :code:`pt` keyword argument can be used to override this. If not :code:`None`
+    the value of this argument will be used to control the thickness of the line
+    used to draw the circle.
+    """
+
+    xc = x - x0
+    yc = y - y0
+    circle = np.sqrt(xc * xc + yc * yc)
+
+    if pt is None:
+        return circle < r * r
+
+    R = (r + pt) ** 2
+    r = (r - pt) ** 2
+
+    return np.logical_and(r < circle, circle < R)
+
+
+@shape
+def Ellipse(x, y, *, x0=0, y0=0, a=2, b=1, r=0.8):
+    """An ellipse."""
+
+    xc = (x - x0) ** 2
+    yc = (y - y0) ** 2
+
+    a = a * a
+    b = b * b
+
+    return np.sqrt(xc / a + yc / b) < r * r
+
+
+@shape
+def Square(x, y, *, x0=0, y0=0, size=0.8):
+    """A square."""
+
+    xc = x - x0
+    yc = y - y0
+
+    size = size / 2
+
+    return np.logical_and(np.abs(xc) < size, np.abs(yc) < size)

--- a/tests/doc/test_directives.py
+++ b/tests/doc/test_directives.py
@@ -1,0 +1,82 @@
+import py.test
+import stylo as st
+from docutils.statemachine import StringList
+from stylo.doc.directives import format_error, load_shape
+
+
+class TestLoadShape:
+    """Tests for the :code:`load_shape` function."""
+
+    def test_bad_module_name(self):
+        """Ensure that a :code:`ModuleNotFoundError` is raised if a bad module
+        name is given."""
+
+        with py.test.raises(ModuleNotFoundError) as err:
+            load_shape("badmod.Circle")
+
+        assert "badmod" in str(err.value)
+
+    def test_bad_module_path(self):
+        """Ensure that a :code:`ModuleNotFoundError` is raised if a bad submodule
+        name is given."""
+
+        with py.test.raises(ModuleNotFoundError) as err:
+            load_shape("stylo.badmod.Circle")
+
+        assert "stylo.badmod" in str(err.value)
+
+    def test_bad_object_name(self):
+        """Ensure that an :code:`AttributeError` is raised if an object name is
+        given that does not exist"""
+
+        with py.test.raises(AttributeError) as err:
+            load_shape("stylo.lib.basic.BadShapeName")
+
+        assert "stylo.lib.basic" in str(err.value)
+        assert "BadShapeName" in str(err.value)
+
+    def test_bad_object_type(self):
+        """Ensure that a :code:`TypeError` is raised if an object is not a shape."""
+
+        with py.test.raises(TypeError) as err:
+            load_shape("stylo.doc.directives.AutoShapeDirective")
+
+        assert "is not a shape" in str(err.value)
+        assert "AutoShapeDirective" in str(err.value)
+
+    def test_load_shape(self):
+        """Ensure that we can load a shape."""
+
+        circle = load_shape("stylo.lib.basic.Circle")
+        assert issubclass(circle, st.Shape)
+
+
+class TestFormatError:
+    """Tests for the :code:`format_error` function."""
+
+    def test_formatter(self):
+
+        err = "\n".join(
+            [
+                "Traceback (most recent call last):",
+                '   File "<stdin>", line 1, in <module>',
+                "ZeroDivisionError: division by zero",
+            ]
+        )
+        content = format_error("Unable to perform :code:`2 / 0`", err)
+
+        assert isinstance(content, StringList)
+
+        actual = list(content)
+        expected = [
+            ".. error::",
+            "",
+            "   Unable to perform :code:`2 / 0`::",
+            "",
+            "      Traceback (most recent call last):",
+            '         File "<stdin>", line 1, in <module>',
+            "      ZeroDivisionError: division by zero",
+            "",
+        ]
+
+        assert expected == actual

--- a/tests/test_loaders.py
+++ b/tests/test_loaders.py
@@ -6,7 +6,6 @@ import py.test
 from stylo.loaders import Collection
 
 
-@py.test.mark.core
 class TestCollection:
     """Tests for the :code:`Collection` class."""
 

--- a/tests/test_loaders.py
+++ b/tests/test_loaders.py
@@ -6,6 +6,7 @@ import py.test
 from stylo.loaders import Collection
 
 
+@py.test.mark.core
 class TestCollection:
     """Tests for the :code:`Collection` class."""
 

--- a/tests/test_shapes.py
+++ b/tests/test_shapes.py
@@ -5,6 +5,7 @@ import py.test
 import stylo as st
 
 
+@py.test.mark.core
 class TestShape:
     """Tests for the `st.shape` decorator and the base `Shape` class."""
 

--- a/tests/test_shapes.py
+++ b/tests/test_shapes.py
@@ -5,7 +5,6 @@ import py.test
 import stylo as st
 
 
-@py.test.mark.core
 class TestShape:
     """Tests for the `st.shape` decorator and the base `Shape` class."""
 


### PR DESCRIPTION
- In the sprit of the autodoc extension this adds an `autoshape`
  directive that we can use to automatically write the reference
  documentation for a shape. It currently does the following:
  + Generates an example image based on the default property values
  + Inserts the shape's docstring
  + Inserts a list of all of the properties and their default values.
- Moved the shape definitions from `stylo/shapes.py` to the beginnings
  of a "standard library" in `stylo/lib/basic.py`