### PR TITLE
Author tutorials as part of the docs, export to jupyter notebooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,6 +10,8 @@ repos:
   hooks:
   - id: isort
     exclude: 'solutions'
+    additional_dependencies:
+    - 'toml'
 
 - repo: https://github.com/python/black
   rev: master

--- a/docs/using/index.rst
+++ b/docs/using/index.rst
@@ -4,3 +4,8 @@ User Guide
 ==========
 
 This is how we do it
+
+.. toctree::
+   :maxdepth: 2
+
+   tutorial/index

--- a/docs/using/tutorial/getstarted/index.rst
+++ b/docs/using/tutorial/getstarted/index.rst
@@ -1,0 +1,11 @@
+.. _using_tutorial_getstarted:
+
+Getting Started
+===============
+
+.. nbtutorial::
+
+Are you new to stylo? Not sure what this is all about yet? Well not to worry
+that is what this section is all about! Hopefully after you work your way
+through the next few pages you will have a much better idea about stylo, what
+it is and how to use it.

--- a/docs/using/tutorial/getstarted/index.rst
+++ b/docs/using/tutorial/getstarted/index.rst
@@ -9,3 +9,8 @@ Are you new to stylo? Not sure what this is all about yet? Well not to worry
 that is what this section is all about! Hopefully after you work your way
 through the next few pages you will have a much better idea about stylo, what
 it is and how to use it.
+
+.. toctree::
+   :hidden:
+
+   shapes-and-images

--- a/docs/using/tutorial/getstarted/shapes-and-images.rst
+++ b/docs/using/tutorial/getstarted/shapes-and-images.rst
@@ -1,0 +1,34 @@
+.. _using_tutorial_getstarted_part1:
+
+Shapes and Images
+=================
+
+.. nbtutorial::
+
+In this tutorial we start you off by introducing you to the two main types of
+object you will find in :code:`stylo` as well as how to use them to create your
+first image. The first of these objects are the :code:`Shapes`.
+
+:code:`Shapes` define the rules that are used to contruct our second kind of
+object :code:`Images`. An :code:`Image` contains the raw image data that we can
+manipulate before saving it as a file. :code:`Images` are typically constructed
+using one or more shapes.
+
+Let's show you what I mean, first import the Shapes collection and create an
+instance of the :code:`Circle` shape.
+
+.. doctest::
+
+   >>> from stylo import Shapes as S
+   >>> circle = S.Circle()
+   >>> circle
+   Circle(x0=0, y0=0, r=0.8, pt=None)
+
+As you can see each shape can carry its own set of properties that can be
+tweaked to change how it looks when it is drawn. For now don't worry about them
+too much as we will get to look at those in more detail later. Instead let's
+focus on making our first image!
+
+Every shape instance can be called as a function and will return an image
+contiaing itself, all we need to do is tell it how large we want the image to
+be!

--- a/docs/using/tutorial/index.rst
+++ b/docs/using/tutorial/index.rst
@@ -3,6 +3,13 @@
 Tutorial
 ========
 
+.. toctree::
+   :hidden:
+
+   getstarted/index
+
+.. nbtutorial::
+
 
 .. only:: html
 
@@ -16,8 +23,6 @@ Tutorial
       This will start a `Jupyter Lab`_ instance that contains an interactive notebook
       version of this tutorial.
 
-.. nbtutorial::
-
 Welcome to stylo's tutorial! If this is your first time here please do take the
 time to read through this page to help you get the most out of it. However
 before we go any further it is worth checking that stylo has been properly set
@@ -29,8 +34,8 @@ up
    >>> st.__version__
    '0.10.0'
 
-What this Tutorial Covers
--------------------------
+About this Tutorial
+-------------------
 
 This tutorial is broken down into a number of sections each focused on a
 particular aspect of stylo. The sections are self contained so feel free to
@@ -42,7 +47,9 @@ used in practise.
 
 Currently the following sections are available.
 
-- **Getting Started:** If you are new to stylo start here.
+.. |Getting Started| replace:: :ref:`Getting Started: <using_tutorial_getstarted>`
+
+- |Getting Started| If you are new to stylo start here.
 - **Background:** There are a number of mathematical concepts at play in the
   core of stylo. While it's not necessary to understand them it can certainly
   help to at least be familiar with them. The tutorials in this section aim to

--- a/docs/using/tutorial/index.rst
+++ b/docs/using/tutorial/index.rst
@@ -13,20 +13,41 @@ Tutorial
 
           $ stylo tutorial
 
-.. only:: nbtutorial
+      This will start a `Jupyter Lab`_ instance that contains an interactive notebook
+      version of this tutorial.
 
-   .. nbtutorial::
+.. nbtutorial::
 
 Welcome to stylo's tutorial! If this is your first time here please do take the
-time to read through this page to help you get the most out of it. However before
-we go any further it is worth checking that stylo has been properly set up
+time to read through this page to help you get the most out of it. However
+before we go any further it is worth checking that stylo has been properly set
+up
 
-.. testcode::
+.. doctest::
 
-   import stylo as st
+   >>> import stylo as st
+   >>> st.__version__
+   '0.10.0'
 
 What this Tutorial Covers
 -------------------------
+
+This tutorial is broken down into a number of sections each focused on a
+particular aspect of stylo. The sections are self contained so feel free to
+jump around and see where your interests take you. However keep in mind that
+each of tutorials within a section will build up each other so be sure to
+tackle them in order. Each tutorial will contain a number of examples and some
+short excercises which aim to demonstrate the core ideas and how they can be
+used in practise.
+
+Currently the following sections are available.
+
+- **Getting Started:** If you are new to stylo start here.
+- **Background:** There are a number of mathematical concepts at play in the
+  core of stylo. While it's not necessary to understand them it can certainly
+  help to at least be familiar with them. The tutorials in this section aim to
+  introduce these concepts to you.
+
 
 .. only:: nbtutorial
 
@@ -45,3 +66,6 @@ What this Tutorial Covers
    **This command will revert any changes you make to the tutorial - including
    deleting any additional notebooks you have created. Be sure to back up anything
    you wish to save before running this command.**
+
+
+.. _Jupyter Lab: https://jupyterlab.readthedocs.io/en/stable/

--- a/docs/using/tutorial/index.rst
+++ b/docs/using/tutorial/index.rst
@@ -1,0 +1,47 @@
+.. _using_tutorial:
+
+Tutorial
+========
+
+
+.. only:: html
+
+   .. note::
+
+      There is also an interactive version of this tutorial available if you have
+      :code:`stylo` setup on your machine. It can be launched by running the command::
+
+          $ stylo tutorial
+
+.. only:: nbtutorial
+
+   .. nbtutorial::
+
+Welcome to stylo's tutorial! If this is your first time here please do take the
+time to read through this page to help you get the most out of it. However before
+we go any further it is worth checking that stylo has been properly set up
+
+.. testcode::
+
+   import stylo as st
+
+What this Tutorial Covers
+-------------------------
+
+.. only:: nbtutorial
+
+   Resetting the Tutorial
+   ----------------------
+
+   You are free to play around with and change **any** of the code you see here
+   in this tutorial - in fact we encourage it! The only way you are truly going
+   to develop an intuition for how the various concepts in stylo interact is to
+   experiment. Dont't worry about breaking anything either, if you ever get to
+   the point where you wish you could start over you can! At any time you can
+   relaunch the tutorial with the command :code:`stylo tutorial --reset` which
+   will reset **everything** back to its default state so that you can start
+   fresh.
+
+   **This command will revert any changes you make to the tutorial - including
+   deleting any additional notebooks you have created. Be sure to back up anything
+   you wish to save before running this command.**

--- a/docs/using/tutorial/index.rst
+++ b/docs/using/tutorial/index.rst
@@ -25,8 +25,8 @@ Tutorial
 
 Welcome to stylo's tutorial! If this is your first time here please do take the
 time to read through this page to help you get the most out of it. However
-before we go any further it is worth checking that stylo has been properly set
-up
+before we go any further it is worth checking that you have the latest version
+of :code:`stylo`
 
 .. doctest::
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,7 @@ deps =
      sphinx_rtd_theme
 commands =
     sphinx-build -M linkcheck docs docs/_build -E -a -j auto {posargs}
+    sphinx-build -M doctest docs docs/_build -E -a -j auto {posargs}
     sphinx-build -M html docs docs/_build -E -a -j auto {posargs}
 
 [testenv:docs-preview]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,10 @@ ignore = [
   "tests",
   "tests/*"]
 
+[tool.isort]
+multi_line_output = 3
+include_trailing_comma = true
+
 [tool.tox]
 legacy_tox_ini = """
 [tox]

--- a/setup.py
+++ b/setup.py
@@ -60,6 +60,7 @@ setup(
     ],
     entry_points={
         "console_scripts": ["stylo = stylo.__main__:cli"],
+        "sphinx.builders": ["nbtutorial = stylo.doc"],
         "stylo.cli.commands": ["tutorial = stylo.cli.tutorial:register"],
         "stylo.parameters": [
             "x = stylo.parameters:xs",

--- a/stylo/doc/__init__.py
+++ b/stylo/doc/__init__.py
@@ -4,13 +4,23 @@ import stylo
 from sphinx.application import Sphinx
 
 from .builder import NotebookTutorialBuilder
-from .directives import NBTutorialDirective  # noqa: F401
-from .directives import AutoShapeDirective, nbtutorial
+from .directives import (
+    AutoShapeDirective,
+    NBTutorialDirective,
+    depart_nbtutorial,
+    nbtutorial,
+    visit_nbtutorial,
+)
 
 
 def setup(app: Sphinx) -> typing.Dict[str, typing.Any]:
 
-    app.add_node(nbtutorial)
+    app.add_node(
+        nbtutorial,
+        html=(visit_nbtutorial, depart_nbtutorial),
+        latex=(visit_nbtutorial, depart_nbtutorial),
+        text=(visit_nbtutorial, depart_nbtutorial),
+    )
     app.add_builder(NotebookTutorialBuilder)
 
     app.add_directive("autoshape", AutoShapeDirective)

--- a/stylo/doc/__init__.py
+++ b/stylo/doc/__init__.py
@@ -4,11 +4,16 @@ import stylo
 from sphinx.application import Sphinx
 
 from .builder import NotebookTutorialBuilder
-from .directives import AutoShapeDirective  # noqa: F401
+from .directives import NBTutorialDirective  # noqa: F401
+from .directives import AutoShapeDirective, nbtutorial
 
 
 def setup(app: Sphinx) -> typing.Dict[str, typing.Any]:
+
+    app.add_node(nbtutorial)
     app.add_builder(NotebookTutorialBuilder)
+
     app.add_directive("autoshape", AutoShapeDirective)
+    app.add_directive("nbtutorial", NBTutorialDirective)
 
     return {"version": stylo.__version__, "parallel_read_safe": True}

--- a/stylo/doc/__init__.py
+++ b/stylo/doc/__init__.py
@@ -3,10 +3,12 @@ import typing
 import stylo
 from sphinx.application import Sphinx
 
+from .builder import NotebookTutorialBuilder
 from .directives import AutoShapeDirective  # noqa: F401
 
 
 def setup(app: Sphinx) -> typing.Dict[str, typing.Any]:
+    app.add_builder(NotebookTutorialBuilder)
     app.add_directive("autoshape", AutoShapeDirective)
 
     return {"version": stylo.__version__, "parallel_read_safe": True}

--- a/stylo/doc/builder.py
+++ b/stylo/doc/builder.py
@@ -1,0 +1,87 @@
+import os
+import typing
+
+import attr
+from docutils.nodes import Node
+from sphinx.builders import Builder
+from sphinx.util import logging
+
+logger = logging.getLogger(__name__)
+
+
+@attr.s(auto_attribs=True)
+class NotebookCell:
+    """Represents a notebook cell."""
+
+    cell_type: str
+    execution_count: int = None
+    metadata: typing.Dict[str, typing.Any] = attr.Factory(dict)
+    outputs: typing.List[typing.Any] = attr.Factory(list)
+    source: typing.List[str] = attr.Factory(list)
+
+    @classmethod
+    def code(cls):
+        """Create a code cell type"""
+        return cls("code")
+
+
+@attr.s(auto_attribs=True)
+class Notebook:
+    """Represents a notebook."""
+
+    nbformat: int = 4
+    nbformat_minor: int = 2
+    metadata: typing.Dict[str, typing.Any] = attr.Factory(dict)
+    cells: typing.List[NotebookCell] = attr.Factory(list)
+
+    @classmethod
+    def fromcells(cls, cells: typing.List[NotebookCell]):
+        return cls(cells=cells)
+
+    @property
+    def json(self):
+        return attr.asdict(self)
+
+
+class NotebookTutorialBuilder(Builder):
+    """Builder that can convert static tutorials into an interactive jupyer
+    notebook."""
+
+    name = "nbtutorial"
+    format = "ipynb"
+
+    def init(self) -> None:
+        """Any initialization goes here."""
+        logger.info(f"[nbtutorial]: Outdir is: {self.outdir}")
+
+    def get_outdated_docs(self) -> typing.Union[str, typing.Iterable[str]]:
+        """Not too sure what we should do here yet."""
+
+        return ""
+
+    def get_target_uri(self, docname: str, typ: str = None) -> str:
+        """Another method to figure out."""
+
+        uri = docname + ".ipynb"
+
+        logger.info(f"[nbtutorial]: Target URI: {uri}")
+
+        return uri
+
+    def prepare_writing(self, docnames: typing.Set[str]) -> None:
+        """A place we can add logic to?"""
+        pass
+
+    def write_doc(self, docname: str, doctree: Node) -> None:
+        logger.info(f"[nbtutorial]: Called on {docname}")
+        logger.info(f"[nbtutorial]: Has doctree {doctree}")
+
+        base, fname = os.path.split(docname)
+        basedir = os.path.join(self.outdir, base)
+        outfile = os.path.join(basedir, fname + ".ipynb")
+
+        if not os.path.exists(basedir):
+            os.makedirs(basedir)
+
+        with open(outfile, "w") as f:
+            f.write("A file exists.")

--- a/stylo/doc/directives.py
+++ b/stylo/doc/directives.py
@@ -66,6 +66,14 @@ class nbtutorial(nodes.General, nodes.Element):
     pass
 
 
+def visit_nbtutorial(self, node):
+    pass
+
+
+def depart_nbtutorial(self, node):
+    pass
+
+
 def load_shape(object_spec: str) -> st.Shape:
     """Given a classpath e.g. :code:`stylo.shapes.Circle` load it."""
 

--- a/stylo/doc/directives.py
+++ b/stylo/doc/directives.py
@@ -62,6 +62,10 @@ PREVIEW_TEMPLATE = """\
 """
 
 
+class nbtutorial(nodes.General, nodes.Element):
+    pass
+
+
 def load_shape(object_spec: str) -> st.Shape:
     """Given a classpath e.g. :code:`stylo.shapes.Circle` load it."""
 
@@ -184,3 +188,8 @@ class AutoShapeDirective(rst.Directive):
         nested_parse_with_titles(self.state, content, section)
 
         return section.children
+
+
+class NBTutorialDirective(rst.Directive):
+    def run(self):
+        return [nbtutorial("")]

--- a/tests/doc/test_builder.py
+++ b/tests/doc/test_builder.py
@@ -18,12 +18,14 @@ class TestNotebook:
                     "execution_count": None,
                     "metadata": {},
                     "outputs": [],
-                    "source": [],
-                }
+                    "source": ["\n"],
+                },
+                {"cell_type": "markdown", "metadata": {}, "source": ["\n"]},
             ],
         }
 
-        cell = NotebookCell.code()
-        nb = Notebook.fromcells([cell])
+        code = NotebookCell.code()
+        markdown = NotebookCell.markdown()
+        nb = Notebook.fromcells([code, markdown])
 
         assert expected == nb.json

--- a/tests/doc/test_builder.py
+++ b/tests/doc/test_builder.py
@@ -1,0 +1,29 @@
+from stylo.doc.builder import Notebook, NotebookCell
+
+
+class TestNotebook:
+    """Tests for the :code:`Notebook` class."""
+
+    def test_to_json(self):
+        """Ensure that we can convert a :code:`Notebook` instance into a valid
+        notebook."""
+
+        expected = {
+            "nbformat": 4,
+            "nbformat_minor": 2,
+            "metadata": {},
+            "cells": [
+                {
+                    "cell_type": "code",
+                    "execution_count": None,
+                    "metadata": {},
+                    "outputs": [],
+                    "source": [],
+                }
+            ],
+        }
+
+        cell = NotebookCell.code()
+        nb = Notebook.fromcells([cell])
+
+        assert expected == nb.json


### PR DESCRIPTION
**Summary**

- Extend the `stylo.doc` module to:
  + Include a custom `.. nbtutorial::` directive
  + Include a custom `nbtutorial` sphinx builder.
- The `stylo.doc` module can now be used as a standard sphinx extension.
- Tweaks to `pre-commit` hooks so that `black` and `isort` agree on how multi-line imports should be formatted. 

**Description**

The intention is to have the tutorial available not only as a collection of Jupyter notebooks but also pages in the documentation that people can refer to. In order to do this we should have a single source of truth, otherwise things will almost certainly get out of sync. 

This leaves 2 options

1.  Write the tutorials as jupyter notebooks and somehow include them in a sphinx website
2. Write the tutorials as sphinx documentation pages, somehow exporting them to notebooks. 

I have opted for the second option because
- We can `doctest` the tutorial code
- Being part of a sphinx project we have the opportunity to provide translations of the tutorial!
- It was fun to get this working!

This will of course evolve over time but there are a few extras that I want/need to add sooner rather than later.
- The ability to include solutions to exercises via the `%load` magic
- The `Deploy` pipeline will have to be extended to use sphinx to export the tutorial as notebook files and place them in the relevant folder of the code base before the package is built

This goes some way to resolving #109 #107 